### PR TITLE
Tmhmm.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,12 @@ conda install snakemake fastqc trimmomatic trinity spades transdecoder biopython
          python setup.py install
         ~~~~
         (make sure the conda python is used, or use the full path to python from your conda installation)
+5. Instal [tmhmm.py](https://github.com/dansondergaard/tmhmm.py) via pip:
+~~~~
+pip install tmhmm.py
+~~~~
 
-5. Checkout the transXpress code into the folder in which you will be performing your assembly:
+6. Checkout the transXpress code into the folder in which you will be performing your assembly:
 ~~~~
 git clone https://github.com/transXpress/transXpress-snakemake.git .
 ~~~~

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ conda install snakemake fastqc trimmomatic trinity spades transdecoder biopython
          python setup.py install
         ~~~~
         (make sure the conda python is used, or use the full path to python from your conda installation)
-5. Instal [tmhmm.py](https://github.com/dansondergaard/tmhmm.py) via pip:
+5. Install [tmhmm.py](https://github.com/dansondergaard/tmhmm.py) via pip:
 ~~~~
 pip install tmhmm.py
 ~~~~


### PR DESCRIPTION
Implemented [tmhmm.py](https://github.com/dansondergaard/tmhmm.py) instead of [TMHMM](http://www.cbs.dtu.dk/services/TMHMM/) in rule tmhmm_parallel as mentioned in #17.
The output is slightly different and contains only number of expected helices and short topology string.

Also it seems like it needs to be installed via [pip](https://pypi.org/project/tmhmm.py/) since [conda](https://anaconda.org/dansondergaard/tmhmm.py) version is not maintained and did not behave as expected. 