### PR TITLE
Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ transXpress requires:
 * wget (install via conda)
 * tidyverse (required for Trinity, install via conda)
 * python 3.6, numpy 1.14, scipy 1.0, theano 1.0.1, six 1.11 (required for deeploc, install via conda)
-* [deeploc](http://www.cbs.dtu.dk/cgi-bin/nph-sw_request?deeploc)
+* [deeploc](https://services.healthtech.dtu.dk/service.php?DeepLoc-1.0)
 * tmhmm.py (install via pip)
 * basic Linux utitilies: split, awk, cut, gzip
 
@@ -54,7 +54,7 @@ conda install trinity=2.11 trimmomatic bowtie2 python=3.6 biopython numpy=1.16 s
       * Download deeploc from https://services.healthtech.dtu.dk/service.php?DeepLoc-1.0 (go to Downloads)
       * Install deeploc: 
         ~~~~
-         pip install git+https://github.com/Lasagne/Lasagne.git#egg=Lasagne-0.2.dev1
+         pip install git+https://github.com/Lasagne/Lasagne.git#egg=Lasagne-0.2.dev1 (other requirements for deeploc are already installed via conda)
          python setup.py install
         ~~~~
         (make sure the conda python is used, or use the full path to python from your conda installation)

--- a/README.md
+++ b/README.md
@@ -46,12 +46,15 @@ conda activate transxpress
 conda config --add channels bioconda
 conda config --add channels conda-forge
 conda config --set channel_priority false
-conda install snakemake fastqc trimmomatic trinity spades transdecoder biopython samtools bowtie2 infernal hmmer kallisto blast r bioconductor-edger seqkit wget r-tidyverse python=3.6 numpy=1.14 scipy=1.0 theano=1.0.1 six==1.11 parallel
+conda install "snakemake>=5" fastqc transdecoder samtools infernal hmmer kallisto blast=2.10 seqkit wget
+conda install r bioconductor-edger r-tidyverse 
+conda install trinity=2.11 trimmomatic bowtie2 python=3.6 biopython numpy=1.16 scipy=1.0 theano=1.0.1 six==1.11 parallel spades
 ~~~~
 4. Install deeploc:
-      * Download deeploc from http://www.cbs.dtu.dk/cgi-bin/nph-sw_request?deeploc
+      * Download deeploc from https://services.healthtech.dtu.dk/service.php?DeepLoc-1.0 (go to Downloads)
       * Install deeploc: 
         ~~~~
+         pip install git+https://github.com/Lasagne/Lasagne.git#egg=Lasagne-0.2.dev1
          python setup.py install
         ~~~~
         (make sure the conda python is used, or use the full path to python from your conda installation)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ conda config --add channels conda-forge
 conda config --set channel_priority false
 conda install "snakemake>=5" fastqc transdecoder samtools infernal hmmer kallisto blast=2.10 seqkit wget
 conda install r bioconductor-edger r-tidyverse 
-conda install trinity=2.11 trimmomatic bowtie2 python=3.6 biopython numpy=1.16 scipy=1.0 theano=1.0.1 six==1.11 parallel spades
+conda install "trinity>=2.11" trimmomatic bowtie2 "python>=3.6" biopython numpy=1.16 scipy=1.0 theano=1.0.1 six==1.11 parallel spades
 ~~~~
 4. Install deeploc:
       * Download deeploc from https://services.healthtech.dtu.dk/service.php?DeepLoc-1.0 (go to Downloads)

--- a/Snakefile
+++ b/Snakefile
@@ -3,9 +3,9 @@ import shutil
 import re
 import csv
 import Bio.SeqIO
-import Bio.Alphabet
 import subprocess
 from snakemake.utils import min_version
+from Bio.Seq import Seq
 
 min_version("5.4.1")
 
@@ -25,7 +25,7 @@ rule all:
     "transcriptome.fasta",
     "transcriptome.pep",
     "transcriptome_stats.txt",
-    "transcriptome_exN50.tsv.plot.pdf",
+    "ExN50_plot.pdf",
     "transcriptome_annotated.fasta",
     "transcriptome_annotated.pep",
     "transcriptome_TPM_blast.csv"
@@ -292,7 +292,7 @@ rule trinity_stats:
   output:
     stats="transcriptome_stats.txt",
     exN50="transcriptome_exN50.tsv",
-    exN50plot="transcriptome_exN50.tsv.plot.pdf"
+    exN50plot="ExN50_plot.pdf"
   log:
     "logs/trinity_exN50.log"
   params:


### PR DESCRIPTION
README.md changes:
- conda dependencies splitted into 3 groups
- deeploc link change

Snakefile changes:
- #24 Bio.Alphabet was removed from Biopython  https://biopython.org/wiki/Alphabet #24 
- Adding Seq module for string to Seq coversion
- Trinity plot_ExN50_statistic.Rscript creates file called ExN50_plot.pdf in trinity_stats rule