### PR TITLE
Respect availaible CPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,22 @@ conda install "trinity>=2.11" trimmomatic bowtie2 "python>=3.6" biopython numpy=
 ~~~~
 5. Install deeploc:
       * Download deeploc from https://services.healthtech.dtu.dk/service.php?DeepLoc-1.0 (go to Downloads)
-      * Install deeploc: 
+      * Unpack and install deeploc:
         ~~~~
-         pip install git+https://github.com/Lasagne/Lasagne.git#egg=Lasagne-0.2.dev1 (other requirements for deeploc are already installed via conda)
+         tar zxvf deeploc-1.0.All.tar.gz
+         cd deeploc-1.0
+         pip install git+https://github.com/Lasagne/Lasagne.git (other requirements for deeploc like Numpy, Scipy, Theano==1.01 are already installed via conda)
+         # install deeploc itself
          python setup.py install
         ~~~~
         (make sure the conda python is used, or use the full path to python from your conda installation)
 6. Install targetp 2.0:
-      * Download targetp 2.0 from http://www.cbs.dtu.dk/services/TargetP/ (go to Portable version)
-      * add path to targetp /bin/ folder to the PATH variable
+      * Download TargetP 2.0 from https://services.healthtech.dtu.dk/software.php
+      * extract the tarball and add path to targetp /bin/ folder to the PATH variable
+        ~~~~
+         tar zxvf targetp-2.0.Linux.tar.gz
+         export PATH=$PATH:`pwd`/targetp-2.0/bin
+        ~~~~
 7. Install [tmhmm.py](https://github.com/dansondergaard/tmhmm.py) via pip:
 ~~~~
 pip install tmhmm.py
@@ -78,7 +85,7 @@ pip install tmhmm.py
 ~~~~
 git clone https://github.com/transXpress/transXpress-snakemake.git .
 ~~~~
-or create transXpress folder
+or get ./transXpress folder created automatically
 ~~~~
 git clone https://github.com/transXpress/transXpress-snakemake.git
 ~~~~

--- a/Snakefile
+++ b/Snakefile
@@ -4,7 +4,7 @@ import re
 import csv
 import Bio.SeqIO
 import subprocess
-from snakemake.utils import min_version
+from snakemake.utils import min_version, available_cpu_count
 from Bio.Seq import Seq
 
 min_version("5.4.1")
@@ -203,7 +203,7 @@ rule trinity_inchworm_chrysalis:
   params:
     memory="200"
   threads:
-    16
+    available_cpu_count()
   shell:
     """
     Trinity --no_distributed_trinity_exec --max_memory {params.memory}G --CPU {threads} --samples_file {input} {config[trinity_parameters]} {config[strand_specific]} &> {log}
@@ -280,7 +280,7 @@ rule trinity_final:
   params:
     memory="200"
   threads:
-    16
+    available_cpu_count()
   shell:
     """
     Trinity --max_memory {params.memory}G --CPU {threads} --samples_file {input.samples} {config[trinity_parameters]} {config[strand_specific]} &>> {log}
@@ -299,7 +299,7 @@ rule rnaspades:
   params:
     memory="200"
   threads:
-    16
+    available_cpu_count()
   shell:
     """
     ##TODO = kmer shouldn't be fixed, & should be configurable from the beginning of the script (did run into some bugs with the auto parameter)
@@ -397,7 +397,7 @@ rule align_reads:
   params:
     memory="100"
   threads:
-    16
+    available_cpu_count()
   shell:
     """
     {TRINITY_HOME}/util/align_and_estimate_abundance.pl --transcripts {input[1]} {config[strand_specific]} --seqType fq --samples_file {input[0]} --prep_reference --thread_count {threads} --est_method RSEM --aln_method bowtie2 --gene_trans_map {input[2]} &> {log}
@@ -505,9 +505,9 @@ rule rfam_parallel:
   log:
     "logs/rfam_{index}.log"
   params:
-    memory="8" # increased memory from 2 to 8 becuase it was not sufficient
+    memory="8" # increased memory from 2 to 8 because it was not sufficient
   threads:
-    2
+    available_cpu_count()
   shell:
     """
     cmscan -E {config[e_value_threshold]} --rfam --cpu {threads} --tblout {output} {input[db]} {input[fasta]} &> {log}
@@ -525,7 +525,7 @@ rule pfam_parallel:
   params:
     memory="2"
   threads:
-    2
+    available_cpu_count()
   shell:
     """
     hmmscan -E {config[e_value_threshold]} --cpu {threads} --domtblout {output} {input[db]} {input[fasta]} &> {log}
@@ -543,7 +543,7 @@ rule sprot_blastp_parallel:
   params:
     memory="4"
   threads:
-    2
+    available_cpu_count()
   shell:
     """
     blastp -query {input[fasta]} -db {input[db]} -num_threads {threads} -evalue {config[e_value_threshold]} -max_hsps 1 -max_target_seqs 1 -outfmt "6 std stitle" -out {output} &> {log}
@@ -561,7 +561,7 @@ rule sprot_blastx_parallel:
   params:
     memory="4"
   threads:
-    2
+    available_cpu_count()
   shell:
     """
     blastx -query {input[fasta]} -db {input[db]} -num_threads {threads} -evalue {config[e_value_threshold]} -max_hsps 1 -max_target_seqs 1 -outfmt "6 std stitle" -out {output} &> {log}
@@ -694,7 +694,7 @@ rule kallisto:
   params:
     memory="8" # increased memory from 2 to 8 since it was not sufficient
   threads:
-    8
+    available_cpu_count()
   shell:
     """
     {TRINITY_HOME}/util/align_and_estimate_abundance.pl --transcripts {input.transcriptome} {config[strand_specific]} --seqType fq --samples_file {input.samples} --prep_reference --thread_count {threads} --est_method kallisto --gene_trans_map {input.gene_trans_map} &> {log}


### PR DESCRIPTION
The pipeline has hard-coded set of 8 CPUs and e.g. 200GB of RAM, even
to run the test suite. Try to bring the requirements down to respect
exechost.
    
The samtools sort step takes 12GB RAM *per thread*! The 12 GB are hardcoded
somewhere in Trinity.

```    
    --------------------------------------------------------
    -------------------- Chrysalis -------------------------
    -- (Contig Clustering & de Bruijn Graph Construction) --
    --------------------------------------------------------
    
    inchworm_target: /home/mmokrejs/proj/transXpress-snakemake/tests/trinity_out_dir/both.fa
    bowtie_reads_fa: /home/mmokrejs/proj/transXpress-snakemake/tests/trinity_out_dir/both.fa
    chrysalis_reads_fa: /home/mmokrejs/proj/transXpress-snakemake/tests/trinity_out_dir/both.fa
    * [Mon Jul 12 14:01:51 2021] Running CMD: /home/mmokrejs/apps/miniconda3/envs/transxpress/opt/trinity-2.12.0/util/support_scripts/filter_iworm_by_min_length_or_cov.pl /home/mmokrejs/proj/transXpress-snakemake/tests/trinity_out_dir/inchworm.DS.fa 100 10 > /home/mmokrejs/proj/transXpress-snakemake/tests/trinity_out_dir/chrysalis/inchworm.DS.fa.min100
    * [Mon Jul 12 14:01:51 2021] Running CMD: /home/mmokrejs/apps/miniconda3/envs/transxpress/bin/bowtie2-build --threads 8 -o 3 /home/mmokrejs/proj/transXpress-snakemake/tests/trinity_out_dir/chrysalis/inchworm.DS.fa.min100 /home/mmokrejs/proj/transXpress-snakemake/tests/trinity_out_dir/chrysalis/inchworm.DS.fa.min100 1>/dev/null
    * [Mon Jul 12 14:01:51 2021] Running CMD: bash -c " set -o pipefail;/home/mmokrejs/apps/miniconda3/envs/transxpress/bin/bowtie2 --local -k 2 --no-unal --threads 8 -f --score-min G,20,8 -x /home/mmokrejs/proj/transXpress-snakemake/tests/trinity_out_dir/chrysalis/inchworm.DS.fa.min100 /home/mmokrejs/proj/transXpress-snakemake/tests/trinity_out_dir/both.fa  | samtools view -@ 8 -F4 -Sb - | samtools sort -m 13421772800 -@ 8 -no - - > /home/mmokrejs/proj/transXpress-snakemake/tests/trinity_out_dir/chrysalis/iworm.bowtie.nameSorted.bam"
    
    Error encountered::  <!----
    CMD: bash -c " set -o pipefail;/home/mmokrejs/apps/miniconda3/envs/transxpress/bin/bowtie2 --local -k 2 --no-unal --threads 8 -f --score-min G,20,8 -x /home/mmokrejs/proj/transXpress-snakemake/tests/trinity_out_dir/chrysalis/inchworm.DS.fa.min100 /home/mmokrejs/proj/transXpress-snakemake/tests/trinity_out_dir/both.fa  | samtools view -@ 8 -F4 -Sb - | samtools sort -m 13421772800 -@ 8 -no - - > /home/mmokrejs/proj/transXpress-snakemake/tests/trinity_out_dir/chrysalis/iworm.bowtie.nameSorted.bam"  2>tmp.22545.1626091311.stderr
    
    Errmsg:
    samtools sort: couldn't allocate memory for bam_mem
    
    --->
    
    Error, cmd: bash -c " set -o pipefail;/home/mmokrejs/apps/miniconda3/envs/transxpress/bin/bowtie2 --local -k 2 --no-unal --threads 8 -f --score-min G,20,8 -x /home/mmokrejs/proj/transXpress-snakemake/tests/trinity_out_dir/chrysalis/inchworm.DS.fa.min100 /home/mmokrejs/proj/transXpress-snakemake/tests/trinity_out_dir/both.fa  | samtools view -@ 8 -F4 -Sb - | samtools sort -m 13421772800 -@ 8 -no - - > /home/mmokrejs/proj/transXpress-snakemake/tests/trinity_out_dir/chrysalis/iworm.bowtie.nameSorted.bam"  2>tmp.22545.1626091311.stderr died with ret 256  at /home/mmokrejs/apps/miniconda3/envs/transxpress/opt/trinity-2.12.0/PerlLib/Pipeliner.pm line 187.
            Pipeliner::run(Pipeliner=HASH(0x55656f7abb30)) called at /home/mmokrejs/apps/miniconda3/envs/transxpress/bin/Trinity line 2078
            main::run_chrysalis("/home/mmokrejs/proj/transXpress-snakemake/tests/trinity_out_d"..., "/home/mmokrejs/proj/transXpress-snakemake/tests/trinity_out_d"..., 200, 500, undef, "/home/mmokrejs/proj/transXpress-snakemake/tests/trinity_out_d"..., "/home/mmokrejs/proj/transXpress-snakemake/tests/trinity_out_d"...) called at /home/mmokrejs/apps/miniconda3/envs/transxpress/bin/Trinity line 1835
            main::run_Trinity() called at /home/mmokrejs/apps/miniconda3/envs/transxpress/bin/Trinity line 1416
            eval {...} called at /home/mmokrejs/apps/miniconda3/envs/transxpress/bin/Trinity line 1415
    
    Trinity run failed. Must investigate error above.
    logs/trinity_inchworm_chrysalis.log
```