### PR TITLE
Do not force NCPUS and MEM when calling run_test.sh via cmdline

### DIFF
--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -2,8 +2,26 @@
 
 SNAKEFILE="../Snakefile"
 
-echo "Running the transXpress-trinity pipeline using snakemake"
-snakemake --snakefile $SNAKEFILE --cores 8 "$@"
+MYCPUS="${PBS_NUM_PPN:-$PBS_NCPUS}"
+MYCPUS="${NCPUS:-all}"
+
+MEM="${PBS_RESC_MEM:-$SLURM_MEM_PER_NODE}"
+if [ ! -z "$PBS_RESC_MEM" ]; then
+    MEM=$ENV{"PBS_RESC_MEM"} / 1024 / 1024 / 1024
+elif [ ! -z "$SLURM_MEM_PER_NODE" ]; then
+    MEM=$SLURM_MEM_PER_NODE
+else
+    MEM=`free -g | grep 'Mem:' | awk '{print $2}'`
+fi
+
+#  the cmdline args override the settings imposed in $SNAKEFILE
+if [ -z "$MYCPUS" ]; then
+    echo "Running the transXpress-trinity pipeline using snakemake using all locally available CPUs"
+    snakemake --snakefile $SNAKEFILE --cores all --resources mem_gb="$MEM" "$@"
+else
+    echo "Running the transXpress-trinity pipeline using snakemake using $MYCPUS CPUs"
+    snakemake --snakefile $SNAKEFILE --cores $MYCPUS --resources mem_gb="$MEM" "$@"
+fi
 
 echo "Making DAG file describing pipeline execution"
 snakemake --snakefile $SNAKEFILE --dag | dot -Tsvg > dag.svg

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -7,7 +7,7 @@ MYCPUS="${NCPUS:-all}"
 
 MEM="${PBS_RESC_MEM:-$SLURM_MEM_PER_NODE}"
 if [ ! -z "$PBS_RESC_MEM" ]; then
-    MEM=$ENV{"PBS_RESC_MEM"} / 1024 / 1024 / 1024
+    MEM=`echo "${PBS_RESC_MEM}"/1024/1024/1024 | bc`
 elif [ ! -z "$SLURM_MEM_PER_NODE" ]; then
     MEM=$SLURM_MEM_PER_NODE
 else


### PR DESCRIPTION
Although https://github.com/transXpress/transXpress-snakemake/pull/36/commits/ca18fb4c12bf4da0597319203ea144faffb0ba64
would set properly detected locally available number of CPUS we nevertheless override that
when calling tests. At least try to get get the meaningful values before calling
snakemake.

Also try to respect available memory by default. Somewhere down the code
Trinity forces it's own requirement to 200GB RAM, dunno where (yet).